### PR TITLE
search: update open query shortcut to cmd-shift-o

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## Unreleased
+
+- 
+
+## Jan 20th, 2022
+
+- Initial release on the [Raycast store](https://www.raycast.com/bobheadxi/sourcegraph)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Unreleased
 
-- 
+- search: the shortcut to open a command is now `Cmd`-`Shift`-`O` ([#3](https://github.com/bobheadxi/raycast-sourcegraph/pull/3))
 
-## Jan 20th, 2022
+## [Jan 20th, 2022](https://github.com/raycast/extensions/pull/708)
 
 - Initial release on the [Raycast store](https://www.raycast.com/bobheadxi/sourcegraph)

--- a/src/components/search.tsx
+++ b/src/components/search.tsx
@@ -218,7 +218,7 @@ function SearchResultItem({
             <OpenInBrowserAction
               title="Open Query"
               url={queryURL}
-              shortcut={{ modifiers: ["ctrl", "shift"], key: "enter" }}
+              shortcut={{ modifiers: ["cmd", "shift"], key: "o" }}
             />
             <CopyToClipboardAction title="Copy Link to Query" content={queryURL} />
           </ActionPanel.Section>


### PR DESCRIPTION
The existing shortcut doesnt seem to work