### PR TITLE
search: revamp peek for content, symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - all: configuration for "Sourcegraph Instance" commands has been moved from the top-level "Search Code" command into the Sourcegraph extension preferences, and has been renamed "Sourcegraph Self-Hosted" for clarity. As a result of this, existing preferences might be reset and need reconfiguring. ([#2](https://github.com/bobheadxi/raycast-sourcegraph/pull/2))
 - notebooks: "Find Search Notebooks" is a new command that allows you to query, peek, open, and create [Sourcegraph Search Notebooks](https://sourcegraph.com/notebooks?tab=explore)! ([#2](https://github.com/bobheadxi/raycast-sourcegraph/pull/2))
+- search: For `content` and `symbol` matches, if there is more than 1 result in the match, the default command when pressing Enter is now an updated peek view that allows you to jump to specific results. ([#4](https://github.com/bobheadxi/raycast-sourcegraph/pull/4))
 - search: the shortcut to open a command is now `Cmd`-`Shift`-`O`. ([#3](https://github.com/bobheadxi/raycast-sourcegraph/pull/3))
 
 ## [Jan 20th, 2022](https://github.com/raycast/extensions/pull/708)

--- a/src/components/findNotebooks.tsx
+++ b/src/components/findNotebooks.tsx
@@ -19,6 +19,7 @@ import { DateTime } from "luxon";
 import { Sourcegraph, instanceName } from "../sourcegraph";
 import { findNotebooks, SearchNotebook } from "../sourcegraph/gql";
 import checkAuthEffect from "../hooks/checkAuthEffect";
+import { copyShortcut, secondaryActionShortcut } from "./shortcuts";
 
 export default function FindNotebooksCommand(src: Sourcegraph) {
   const { state, find } = useNotebooks(src);
@@ -82,6 +83,7 @@ function NotebookResultItem({
   }
   const stars = notebook.stars?.totalCount || 0;
   const author = notebook.creator.displayName || notebook.creator.username;
+  const url = `${src.instance}/notebooks/${notebook.id}`;
   return (
     <List.Item
       id={id}
@@ -101,13 +103,19 @@ function NotebookResultItem({
       }}
       actions={
         <ActionPanel>
-          <OpenInBrowserAction key={randomId()} url={`${src.instance}/notebooks/${notebook.id}`} />
+          <OpenInBrowserAction key={randomId()} url={url} />
           <PushAction
             key={randomId()}
             title="Peek Search Notebook"
             icon={{ source: Icon.MagnifyingGlass }}
             target={<NotebookPeek notebook={notebook} src={src} />}
-            shortcut={{ modifiers: ["cmd"], key: "enter" }}
+            shortcut={secondaryActionShortcut}
+          />
+          <CopyToClipboardAction
+            key={randomId()}
+            title="Copy Search Notebook URL"
+            content={url}
+            shortcut={copyShortcut}
           />
         </ActionPanel>
       }

--- a/src/components/findNotebooks.tsx
+++ b/src/components/findNotebooks.tsx
@@ -33,7 +33,7 @@ export default function FindNotebooksCommand(src: Sourcegraph) {
       isLoading={state.isLoading}
       onSearchTextChange={find}
       searchBarPlaceholder={`Find search notebooks on ${srcName}`}
-      selectedItemId={(state.notebooks?.length > 0) ? 'first-result' : undefined}
+      selectedItemId={state.notebooks?.length > 0 ? "first-result" : undefined}
       throttle
     >
       {!state.isLoading && !state.searchText ? (
@@ -57,14 +57,22 @@ export default function FindNotebooksCommand(src: Sourcegraph) {
         subtitle={`${state.notebooks.length} ${showStarred ? "notebooks" : "results"}`}
       >
         {state.notebooks.map((n, i) => (
-          <NotebookResultItem id={i === 0 ? 'first-result' : undefined} key={randomId()} notebook={n} src={src} />
+          <NotebookResultItem id={i === 0 ? "first-result" : undefined} key={randomId()} notebook={n} src={src} />
         ))}
       </List.Section>
     </List>
   );
 }
 
-function NotebookResultItem({ id, notebook, src }: { id: string | undefined; notebook: SearchNotebook; src: Sourcegraph }) {
+function NotebookResultItem({
+  id,
+  notebook,
+  src,
+}: {
+  id: string | undefined;
+  notebook: SearchNotebook;
+  src: Sourcegraph;
+}) {
   let updated: string | null = null;
   try {
     const d = DateTime.fromISO(notebook.updatedAt);

--- a/src/components/shortcuts/index.ts
+++ b/src/components/shortcuts/index.ts
@@ -1,0 +1,6 @@
+import { KeyboardShortcut } from "@raycast/api";
+
+export const secondaryActionShortcut: KeyboardShortcut = { modifiers: ["cmd"], key: "enter" };
+export const tertiaryActionShortcut: KeyboardShortcut = { modifiers: ["cmd", "shift"], key: "o" };
+
+export const copyShortcut: KeyboardShortcut = { modifiers: ["ctrl", "shift"], key: "c" };

--- a/src/sourcegraph/stream-search/stream.ts
+++ b/src/sourcegraph/stream-search/stream.ts
@@ -3,7 +3,7 @@
 import { AggregableBadge } from "sourcegraph";
 
 // https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/cmd/frontend/graphqlbackend/schema.graphql?L3323&subtree=true
-export type SymbolKind = number;
+export type SymbolKind = string;
 
 // https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/common/src/errors/types.ts?L3&subtree=true
 export interface ErrorLike {


### PR DESCRIPTION
For match types with multiple results, if there is >1 result the default command when pressing `Enter` is now a list of results within a match.

<img width="1139" alt="image" src="https://user-images.githubusercontent.com/23356519/150617598-0072d0ed-92fb-4ad2-9dd5-e8b9359bad0b.png">

<img width="1126" alt="image" src="https://user-images.githubusercontent.com/23356519/150617718-e80b5e34-fe42-4738-8db8-63e70ed12945.png">
