### PR TITLE
search: fix symbol match URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- **search**: Fix URL opened by `symbol` match results. ([#7](https://github.com/bobheadxi/raycast-sourcegraph/pull/7))
+
 ## [Feb 7, 2022](https://github.com/raycast/extensions/pull/833)
 
 - **search**: Fix off-by-one issue when opening `content` match results.

--- a/src/components/search.tsx
+++ b/src/components/search.tsx
@@ -170,7 +170,7 @@ function SearchResultItem({
       title = match.symbols.map((s) => s.name).join(", ");
       subtitle = match.path;
       if (match.symbols.length === 1) {
-        url = `${searchResult.url}${match.symbols[0].url}`;
+        url = `${searchResult.url}#${match.symbols[0].url}`;
       } else {
         multiResult = true;
       }
@@ -246,7 +246,7 @@ function MultiResultPeek({ searchResult }: { searchResult: { url: string; match:
                 title={s.name}
                 subtitle={s.containerName}
                 accessoryTitle={s.kind.toLowerCase()}
-                actions={<ActionPanel>{resultActions(`${searchResult.url}${s.url}`)}</ActionPanel>}
+                actions={<ActionPanel>{resultActions(`${searchResult.url}#${s.url}`)}</ActionPanel>}
               />
             ))}
           </List.Section>

--- a/src/sourcegraph/stream-search/index.ts
+++ b/src/sourcegraph/stream-search/index.ts
@@ -82,7 +82,9 @@ export async function performSearch(
 
       handlers.onResults(
         event.data.map((match): SearchResult => {
-          const url = `${src.instance}${getMatchUrl(match)}`;
+          const matchURL = `${src.instance}${getMatchUrl(match)}`;
+          // Do some pre-processing of results, since some of the API outputs are a bit
+          // confusing, to make it easier later on.
           switch (match.type) {
             case "commit":
               // Commit stuff comes already markdown-formatted?? so strip formatting
@@ -95,8 +97,16 @@ export async function performSearch(
               match.lineMatches.forEach((l) => {
                 l.lineNumber += 1;
               });
+              break;
+            case "symbol":
+              match.symbols.forEach((s) => {
+                // Trim out the path that we already have in matchURL so that we can just
+                // append it, similar to other match types where we append the line number
+                // of the match.
+                s.url = s.url.split("#").pop() || "";
+              });
           }
-          return { url, match };
+          return { url: matchURL, match };
         })
       );
     });


### PR DESCRIPTION
As reported in https://github.com/bobheadxi/raycast-sourcegraph/issues/6 . Symbol match URL is a full path, e.g. 

```
/github.com/sourcegraph/sourcegraph@rockskip-symbols/-/blob/enterprise/internal/rockskip/lib.go#L918:6-918:16
```

The `getMatchURL` copied from `stream.ts` gives us most of the same thing, and I was appending this URL to the match URL, creating an invalid URL. I could append this to `src.instance` instead, but for consistency with content matches which append `?${lineNumber}`, I've added a preprocessor to turn `url` into just the anchor link and append it to the match URL.

Closes https://github.com/bobheadxi/raycast-sourcegraph/issues/6 

Tested:

- single result match, e.g. `repo:github.com/sourcegraph/sourcegraph@rockskip-symbols type:symbol queryBlobs`
- multi result symbol match, e.g. `context:@sourcegrapha/all monitoring type:symbol f:gcp`