### PR TITLE
prefs: remove trailing slash of self-hosted instance URL

### DIFF
--- a/src/sourcegraph/index.ts
+++ b/src/sourcegraph/index.ts
@@ -40,7 +40,7 @@ export function sourcegraphSelfHosted(): Sourcegraph | null {
   const prefs: Preferences = getPreferenceValues();
   if (prefs.customInstance) {
     return {
-      instance: prefs.customInstance,
+      instance: prefs.customInstance.replace(/\/$/, ""),
       token: prefs.customInstanceToken,
       defaultContext: prefs.customInstanceDefaultContext,
     };


### PR DESCRIPTION
Fixes #8

### Test

<img width="1474" alt="CleanShot 2022-02-25 at 16 59 09@2x" src="https://user-images.githubusercontent.com/2946214/155686821-475018ee-8bdf-4979-a68e-d106cd729710.png">

### Lint

```
λ raycast-sourcegraph → λ git main) ✗ → npm run fmt

> fmt
> ray lint --fix

ready - run ESLint
ready - run Prettier
ready - no ESLint or Prettier issues found
λ raycast-sourcegraph → λ git main) ✗ → npm run lint

> lint
> ray lint

ready - run ESLint
ready - run Prettier
ready - no ESLint or Prettier issues found
```

### Followup

- [ ] Make a new release to the Raycast store