### PR TITLE
search: add support for chunkMatches

### DIFF
--- a/src/hooks/search.tsx
+++ b/src/hooks/search.tsx
@@ -104,8 +104,10 @@ export function useSearch(src: Sourcegraph, maxResults: number) {
         },
         onAlert: (alert) => {
           const toast = ExpandableToast(push, "Alert", alert.title, alert.description || "");
-          if (alert.kind === "lucky-search-queries") {
-            toast.style = Toast.Style.Success;
+          switch (alert.kind) {
+            case "smart-search-additional-results":
+            case "smart-search-pure-results":
+              toast.style = Toast.Style.Success;
           }
           toast.show();
         },

--- a/src/sourcegraph/stream-search/index.ts
+++ b/src/sourcegraph/stream-search/index.ts
@@ -95,7 +95,7 @@ export async function performSearch(
             case "content":
               // Line number appears 0-indexed, for ease of use increment it so links
               // aren't off by 1.
-              match.lineMatches.forEach((l) => {
+              match.lineMatches?.forEach((l) => {
                 l.lineNumber += 1;
               });
               break;

--- a/src/sourcegraph/stream-search/stream.ts
+++ b/src/sourcegraph/stream-search/stream.ts
@@ -49,8 +49,17 @@ export interface ContentMatch {
   repoLastFetched?: string;
   branches?: string[];
   commit?: string;
+  // Usages of lineMatches should support chunkMatches as well
   lineMatches: LineMatch[];
+  // Experimental API from https://github.com/sourcegraph/sourcegraph/pull/37582
+  chunkMatches: ChunkMatch[];
   hunks?: DecoratedHunk[];
+}
+
+interface ChunkMatch {
+  content: string;
+  contentStart: Location;
+  ranges: Range[];
 }
 
 export interface DecoratedHunk {

--- a/src/sourcegraph/stream-search/stream.ts
+++ b/src/sourcegraph/stream-search/stream.ts
@@ -39,27 +39,22 @@ export interface PathMatch {
   repoLastFetched?: string;
   branches?: string[];
   commit?: string;
+  debug?: string;
 }
 
 export interface ContentMatch {
   type: "content";
   path: string;
+  pathMatches?: Range[];
   repository: string;
   repoStars?: number;
   repoLastFetched?: string;
   branches?: string[];
   commit?: string;
-  // Usages of lineMatches should support chunkMatches as well
-  lineMatches: LineMatch[];
-  // Experimental API from https://github.com/sourcegraph/sourcegraph/pull/37582
-  chunkMatches: ChunkMatch[];
+  lineMatches?: LineMatch[];
+  chunkMatches?: ChunkMatch[];
   hunks?: DecoratedHunk[];
-}
-
-interface ChunkMatch {
-  content: string;
-  contentStart: Location;
-  ranges: Range[];
+  debug?: string;
 }
 
 export interface DecoratedHunk {
@@ -85,10 +80,16 @@ export interface Location {
   column: number;
 }
 
-interface LineMatch {
+export interface LineMatch {
   line: string;
   lineNumber: number;
   offsetAndLengths: number[][];
+}
+
+interface ChunkMatch {
+  content: string;
+  contentStart: Location;
+  ranges: Range[];
 }
 
 export interface SymbolMatch {
@@ -100,6 +101,7 @@ export interface SymbolMatch {
   branches?: string[];
   commit?: string;
   symbols: MatchedSymbol[];
+  debug?: string;
 }
 
 export interface MatchedSymbol {
@@ -126,6 +128,8 @@ export interface CommitMatch {
   message: string;
   authorName: string;
   authorDate: string;
+  committerName: string;
+  committerDate: string;
   repoStars?: number;
   repoLastFetched?: string;
 
@@ -137,6 +141,7 @@ export interface CommitMatch {
 export interface RepositoryMatch {
   type: "repo";
   repository: string;
+  repositoryMatches?: Range[];
   repoStars?: number;
   repoLastFetched?: string;
   description?: string;
@@ -230,7 +235,7 @@ export interface Filter {
   kind: "file" | "repo" | "lang" | "utility";
 }
 
-export type AlertKind = "lucky-search-queries";
+export type AlertKind = "smart-search-additional-results" | "smart-search-pure-results";
 
 interface Alert {
   title: string;


### PR DESCRIPTION
This hasn't landed upstream yet (https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/shared/src/search/stream.ts?L45-55) but this is WIP support for `chunkMatches` that will replace `lineMatches` eventually: https://github.com/sourcegraph/sourcegraph/pull/37582#issuecomment-1205438695

Closes #17 