### PR TITLE
Support proxying requests over Unix domain socket for custom Sourcegraph instances

### DIFF
--- a/package.json
+++ b/package.json
@@ -186,7 +186,8 @@
     "eventsource": "^2.0.2",
     "graphql": "^16.6.0",
     "luxon": "^3.3.0",
-    "nanoid": "^4.0.2"
+    "nanoid": "^4.0.2",
+    "patch-package": "^8.0.0"
   },
   "devDependencies": {
     "@graphql-codegen/cli": "^3.3.1",
@@ -212,6 +213,7 @@
     "lint": "ray lint",
     "fmt": "ray lint --fix",
     "raycast-publish": ".scripts/raycast-publish.sh",
-    "gql": "graphql-codegen --config graphql-codegen.yml && npm run fmt"
+    "gql": "graphql-codegen --config graphql-codegen.yml && npm run fmt",
+    "postinstall": "patch-package"
   }
 }

--- a/package.json
+++ b/package.json
@@ -43,6 +43,13 @@
       "type": "password"
     },
     {
+      "name": "customInstanceProxy",
+      "title": "Sourcegraph Instance: Proxy",
+      "description": "Optional proxy to use when connecting to a custom Sourcegraph instance. (Presently, only Unix domain sockets are supported.)",
+      "required": false,
+      "type": "textfield"
+    },
+    {
       "name": "featureSearchPatternDropdown",
       "title": "Experimental features",
       "label": "Search pattern dropdown",

--- a/package.json
+++ b/package.json
@@ -182,11 +182,11 @@
     "@apollo/client": "^3.7.12",
     "@raycast/api": "^1.49.3",
     "@raycast/utils": "^1.5.2",
-    "cross-fetch": "^3.1.5",
     "eventsource": "^2.0.2",
     "graphql": "^16.6.0",
     "luxon": "^3.3.0",
     "nanoid": "^4.0.2",
+    "node-fetch": "^3.3.2",
     "patch-package": "^8.0.0"
   },
   "devDependencies": {

--- a/patches/eventsource+2.0.2.patch
+++ b/patches/eventsource+2.0.2.patch
@@ -1,0 +1,15 @@
+diff --git a/node_modules/eventsource/lib/eventsource.js b/node_modules/eventsource/lib/eventsource.js
+index bd401a1..3d2f47a 100644
+--- a/node_modules/eventsource/lib/eventsource.js
++++ b/node_modules/eventsource/lib/eventsource.js
+@@ -143,6 +143,10 @@ function EventSource (url, eventSourceInitDict) {
+       options.withCredentials = eventSourceInitDict.withCredentials
+     }
+ 
++    if (eventSourceInitDict && eventSourceInitDict.agent !== undefined) {
++      options.agent = eventSourceInitDict.agent
++    }
++
+     req = (isSecure ? https : http).request(options, function (res) {
+       self.connectionInProgress = false
+       // Handle HTTP errors

--- a/src/sourcegraph/gql/apollo.ts
+++ b/src/sourcegraph/gql/apollo.ts
@@ -1,15 +1,15 @@
 import { createHttpLink, ApolloClient, InMemoryCache } from "@apollo/client";
 import { setContext } from "@apollo/client/link/context";
-import fetch from "cross-fetch";
 import operations from "./operations";
+import { getProxiedFetch } from "./fetchProxy";
 
-export function newApolloClient(connect: { instance: string; token?: string }) {
+export function newApolloClient(connect: { instance: string; token?: string; proxy?: string }) {
   const httpLink = createHttpLink({
     uri: `${connect.instance}/.api/graphql`,
     headers: {
       "X-Requested-With": "Raycast-Sourcegraph",
     },
-    fetch,
+    fetch: getProxiedFetch(connect.proxy) as unknown as WindowOrWorkerGlobalScope["fetch"],
   });
 
   const authLink = setContext((_, { headers }) => {

--- a/src/sourcegraph/gql/auth.ts
+++ b/src/sourcegraph/gql/auth.ts
@@ -1,6 +1,5 @@
-import fetch from "cross-fetch";
-
 import { Sourcegraph } from "..";
+import { getProxiedFetch } from "./fetchProxy";
 
 export class AuthError extends Error {
   message: string;
@@ -20,7 +19,7 @@ async function doGQLRequest<T>(abort: AbortSignal, src: Sourcegraph, body: strin
     headers["Authorization"] = `token ${src.token}`;
   }
   return new Promise<T>((resolve, reject) => {
-    fetch(`${src.instance}/.api/graphql`, {
+    getProxiedFetch(src.proxy)(`${src.instance}/.api/graphql`, {
       method: "POST",
       headers: headers,
       body,

--- a/src/sourcegraph/gql/fetchProxy.ts
+++ b/src/sourcegraph/gql/fetchProxy.ts
@@ -1,0 +1,30 @@
+import http, { Agent } from "http";
+import path from "path";
+import fetch, { RequestInit, RequestInfo } from "node-fetch";
+
+// Returns a valid http.Agent, using a proxy when configured.
+export function getProxiedAgent(proxy?: string) {
+  if (proxy !== undefined) {
+    if (proxy.startsWith("http://") || proxy.startsWith("https://")) {
+      throw new Error(`The proxy provided (${proxy}) is not supported. Use a Unix socket proxy or unset this option.`);
+    } else {
+      let socketPath = proxy;
+      if (socketPath.startsWith("unix://")) {
+        socketPath = proxy.slice("unix://".length);
+      }
+      if (socketPath.startsWith("~/") && process.env.HOME !== undefined) {
+        socketPath = path.join(process.env.HOME, socketPath.slice(2));
+      }
+      return new Agent({ socketPath } as unknown as http.AgentOptions);
+    }
+  }
+  return http.globalAgent;
+}
+
+// Returns a fetch function that uses a proxy when configured.
+export function getProxiedFetch(proxy?: string): typeof fetch {
+  const agent = getProxiedAgent(proxy);
+  return (info: URL | RequestInfo, init?: RequestInit) => {
+    return fetch(info, { ...init, agent } as RequestInit);
+  };
+}

--- a/src/sourcegraph/index.ts
+++ b/src/sourcegraph/index.ts
@@ -21,6 +21,11 @@ export interface Sourcegraph {
   client: ApolloClient<NormalizedCacheObject>;
 
   /**
+   * Address of the proxy server to use for requests to the custom Sourcegraph instance.
+   */
+  proxy?: string;
+
+  /**
    * Feature flags for the extension.
    */
   featureFlags: ExtensionFeatureFlags;
@@ -54,6 +59,7 @@ interface Preferences {
   customInstance?: string;
   customInstanceToken?: string;
   customInstanceDefaultContext?: string;
+  customInstanceProxy?: string;
 
   // Feature flags
 
@@ -88,6 +94,7 @@ export function sourcegraphInstance(): Sourcegraph | null {
   const connect = {
     instance: prefs.customInstance.replace(/\/$/, ""),
     token: prefs.customInstanceToken,
+    proxy: prefs.customInstanceProxy,
   };
   return {
     ...connect,


### PR DESCRIPTION
This PR adds a setting for custom Sourcegraph instances to have requests proxied over a unix domain socket.

This could be eventually expanded to support HTTP proxies, but I don't have one handy to test with (and I think it might require additional dependencies?).

This does unfortunately require a patch on the `eventsource` package, which is roughly bringing in an upstream PR https://github.com/EventSource/eventsource/pull/143.