### PR TITLE
fix: properly support unproxied fetch again

### DIFF
--- a/package.json
+++ b/package.json
@@ -175,14 +175,14 @@
     "@apollo/client": "^3.11.10",
     "@raycast/api": "^1.86.1",
     "@raycast/utils": "^1.18.1",
-    "node-fetch": "^3.3.2",
+    "cross-fetch": "^4.0.0",
     "eventsource": "^2.0.2",
     "graphql": "^16.9.0",
     "luxon": "^3.5.0",
-    "nanoid": "^5.0.9"
+    "nanoid": "^5.0.9",
+    "node-fetch": "^3.3.2"
   },
   "devDependencies": {
-    "patch-package": "^8.0.0",
     "@graphql-codegen/cli": "^5.0.3",
     "@graphql-codegen/fragment-matcher": "^5.0.2",
     "@graphql-codegen/introspection": "^4.0.3",
@@ -197,6 +197,7 @@
     "@typescript-eslint/parser": "^8.16.0",
     "eslint": "^9.16.0",
     "eslint-config-prettier": "^9.1.0",
+    "patch-package": "^8.0.0",
     "prettier": "^3.4.1",
     "typescript": "^5.7.2"
   },

--- a/src/sourcegraph/gql/fetchProxy.ts
+++ b/src/sourcegraph/gql/fetchProxy.ts
@@ -29,6 +29,7 @@ export function getProxiedFetch(proxy?: string): typeof crossFetch {
   }
   // YOLO, not sure how to get the types to interop but the actual passed parameters
   // match those used in https://github.com/bobheadxi/raycast-sourcegraph/pull/21.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const proxiedFetch = (info: any, init?: any) => {
     return nodeFetch(info as RequestInfo, { ...init, agent } as RequestInit);
   };

--- a/src/sourcegraph/index.ts
+++ b/src/sourcegraph/index.ts
@@ -31,13 +31,13 @@ export interface Sourcegraph {
   featureFlags: ExtensionFeatureFlags;
 }
 
-const cloudURL = "https://sourcegraph.com";
+const dotComURL = "https://sourcegraph.com";
 
 /**
  * isSourcegraphDotCom returns true if this instance URL points to Sourcegraph.com.
  */
 export function isSourcegraphDotCom(instance: string) {
-  return instance === cloudURL;
+  return instance === dotComURL;
 }
 
 /**
@@ -72,7 +72,7 @@ interface Preferences {
 export function sourcegraphDotCom(): Sourcegraph {
   const prefs: Preferences = getPreferenceValues();
   const connect = {
-    instance: cloudURL,
+    instance: dotComURL,
     token: prefs.cloudToken,
   };
   return {


### PR DESCRIPTION
After https://github.com/bobheadxi/raycast-sourcegraph/pull/21 I found that non-proxied usage no longer works, typically with the error:

```
TypeError [ERR_INVALID_PROTOCOL]: Protocol “https:” not supported. Expected “http:”
```

I'm not really sure why this happens; I started with having `getProxiedAgent` return undefined if no proxy is configured, but it seemed that GraphQL requests were still failing. I figured a quick-and-easy answer might be to bring back `cross-fetch` when a proxy isn't configured, which seems to have done the trick.